### PR TITLE
Modified sensor.begin()

### DIFF
--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -143,8 +143,8 @@ boolean MAX30105::begin(TwoWire &wirePort, uint32_t i2cSpeed, uint8_t i2caddr) {
 
   _i2cPort = &wirePort; //Grab which port the user wants us to use
 
-  _i2cPort->begin();
-  _i2cPort->setClock(i2cSpeed);
+  /*_i2cPort->begin();
+  _i2cPort->setClock(i2cSpeed);*/
 
   _i2caddr = i2caddr;
 


### PR DESCRIPTION
We require caller to begin their I2C port, with the speed of their choice external to the library.