### PR TITLE
Feat async temp measurement

### DIFF
--- a/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
+++ b/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
@@ -1,0 +1,117 @@
+/*
+  MAX3010 Breakout: Read the onboard temperature sensor
+  By: Nathan Seidle @ SparkFun Electronics
+  Date: October 20th, 2016
+  https://github.com/sparkfun/MAX30105_Breakout
+
+  This demo outputs the onboard temperature sensor. The temp sensor is accurate to +/-1 C but
+  has an astonishing precision of 0.0625 C.
+
+  Hardware Connections (Breakoutboard to Arduino):
+  -5V = 5V (3.3V is allowed)
+  -GND = GND
+  -SDA = A4 (or SDA)
+  -SCL = A5 (or SCL)
+  -INT = Not connected
+ 
+  The MAX30105 Breakout can handle 5V or 3.3V I2C logic. We recommend powering the board with 5V
+  but it will also run at 3.3V.
+*/
+
+#include <Wire.h>
+
+#include "MAX30105.h"  //Get it here: http://librarymanager/All#SparkFun_MAX30105
+#include "EmotiBitVersionController.h"
+#include "EmotiBitNvmController.h"
+#include "wiring_private.h"
+
+MAX30105 particleSensor;
+TwoWire* emotibitI2c;
+
+char input = 'a';
+
+void setup()
+{
+  Serial.begin(9600);
+  Serial.println("Initializing...");
+
+  EmotiBitVersionController emotibitVersionController;
+  EmotiBitNvmController emotibitNvmController;
+  EmotiBitVersionController::EmotiBitVersion emotibitVersion;
+  String sku;
+  uint32_t emotibitSerialNumber;
+  if (emotibitVersionController.isEmotiBitReady())
+  {
+	  emotibitNvmController.init(*emotibitI2c);
+	  emotibitVersionController.getEmotiBitVariantInfo(emotibitNvmController, emotibitVersion, sku, emotibitSerialNumber);
+  }
+  else
+  {
+	  while (1)
+	  {
+		  Serial.println("please check SD-Card and battery.");
+		  delay(1000);
+	  }
+  }
+  emotibitI2c = new TwoWire(&sercom1, 11, 13); // data, clk
+  emotibitI2c->begin();
+  emotibitI2c->setClock(400000);
+  pinPeripheral(11, PIO_SERCOM);
+  pinPeripheral(13, PIO_SERCOM);
+  
+  // Initialize sensor
+  if (particleSensor.begin(*emotibitI2c, I2C_SPEED_FAST) == false) //Use default I2C port, 400kHz speed
+  {
+    Serial.println("MAX30105 was not found. Please check wiring/power. ");
+    while (1);
+  }
+
+  //The LEDs are very low power and won't affect the temp reading much but
+  //you may want to turn off the LEDs to avoid any local heating
+  particleSensor.setup(0); //Configure sensor. Turn off LEDs
+  //particleSensor.setup(); //Configure sensor. Use 25mA for LED drive
+
+  particleSensor.enableDIETEMPRDY(); //Enable the temp ready interrupt. This is required.
+  Serial.println("Setup complete");
+  Serial.println("Start time: " + String(millis()));
+
+}
+
+void loop()
+{
+	
+	if (Serial.available())
+	{
+		input = Serial.read();
+	}
+	if (input == 'a')
+	{
+		float temperature = 0;
+		if (particleSensor.readTemperature(temperature))
+		{
+			Serial.print("[Time: " + String(millis()) + "]");
+			Serial.print("temperature: ");
+			Serial.println(temperature,4);
+		}
+		else
+		{
+			Serial.println("[Time: " + String(millis()) + "]" + "Temp data not ready");
+		}
+		delay(50);
+	}
+	else if(input == 's')
+	{
+		float temperature = particleSensor.readTemperature();
+		
+		Serial.print("[Time: " + String(millis()) + "]");
+		Serial.print("temperature: ");
+		Serial.print(temperature, 4);
+
+		//float temperatureF = particleSensor.readTemperatureF(); //Because I am a bad global citizen
+
+		//Serial.print(" temperatureF=");
+		//Serial.print(temperatureF, 4);
+
+		Serial.println();
+	}
+}

--- a/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
+++ b/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
@@ -106,7 +106,7 @@ void loop()
 		{
 			Serial.println("[Async] [Time: " + String(millis()) + "]" + "Temp data not ready");
 		}
-		delay(20); // less than 29ms, which is the conversion time of the sensor
+		delay(10); // less than 29ms, which is the conversion time of the sensor
 	}
 	else if(input == 's')
 	{

--- a/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
+++ b/examples/Example10_Temperature_Sense_Async/Example10_Temperature_Sense_Async.ino
@@ -31,6 +31,7 @@ TwoWire* emotibitI2c;
 char input = 'a';
 uint32_t currentPrintTime;
 uint32_t lastPrintTime;
+bool firstTime = true;
 
 void setup()
 {
@@ -93,14 +94,20 @@ void loop()
 	}
 	if (input == 'a')
 	{
+		if (firstTime)
+		{
+			particleSensor.startTempMeasurement();
+			firstTime = false;
+		}
 		float temperature = 0;
-		if (particleSensor.readTemperatureAsync(temperature)) // call readTemperatureFAsync for fahrenheit
+		if (particleSensor.getTemperature(temperature)) // call readTemperatureFAsync for fahrenheit
 		{
 			currentPrintTime = millis();
 			Serial.print("[Async] [Time: " + String(currentPrintTime) + "]" + "[time since last measurement: " + String(currentPrintTime - lastPrintTime) + "] ");
 			Serial.print("temperature: ");
 			Serial.println(temperature,4);
 			lastPrintTime = currentPrintTime;
+			particleSensor.startTempMeasurement();
 		}
 		else
 		{
@@ -110,6 +117,7 @@ void loop()
 	}
 	else if(input == 's')
 	{
+		firstTime = true; // resetting incase we switch back to async measurement
 		float temperature = particleSensor.readTemperature();// call readTemperatureF for fahrenheit
 		
 		currentPrintTime = millis();

--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -361,7 +361,7 @@ uint8_t MAX30105::getReadPointer(void) {
 }
 
 
-bool MAX30105::readTemperature(float& temperature)
+bool MAX30105::readTemperatureAsync(float& temperature)
 {
 	uint8_t isBusy = readRegister8(_i2caddr, MAX30105_DIETEMPCONFIG);
 	if (isBusy & 0x01)
@@ -428,6 +428,20 @@ float MAX30105::readTemperature(bool isAsync) {
 
   // Step 3: Calculate temperature (datasheet pg. 23)
   return (float)tempInt + ((float)tempFrac * 0.0625);
+}
+
+// Returns die temp in F Asynchronously
+bool MAX30105::readTemperatureFAsync(float& temperature)
+{
+	float temp;
+	if (!readTemperatureAsync(temp))
+	{
+		return false;
+	}
+	
+	if (temp != -999.0) temp = temp * 1.8 + 32.0;
+	temperature = temp;
+	return true;
 }
 
 // Returns die temp in F

--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -430,7 +430,7 @@ bool MAX30105::getTemperatureF(float& temperature)
 		return false;
 	}
 	
-	if (temp != -999.0) temp = temp * 1.8 + 32.0;
+	temp = temp * 1.8 + 32.0;
 	temperature = temp;
 	return true;
 }

--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -361,23 +361,19 @@ uint8_t MAX30105::getReadPointer(void) {
 }
 
 
-void MAX30105::startTempMeasurement()
-{
+void MAX30105::startTempMeasurement() {
 	// setting appropriate bit to start temp measurement
 	writeRegister8(_i2caddr, MAX30105_DIETEMPCONFIG, 0x01);
 }
 
-bool MAX30105::getTemperature(float& temperature)
-{
+bool MAX30105::getTemperature(float& temperature) {
 	uint8_t isTempMeasurementReady = readRegister8(_i2caddr, MAX30105_INTSTAT2);
-	if (isTempMeasurementReady & MAX30105_INT_DIE_TEMP_RDY_ENABLE)
-	{
+	if (isTempMeasurementReady & MAX30105_INT_DIE_TEMP_RDY_ENABLE) {
 		// temp measurement available!
 		temperature = readTemperature(true);
 		return true;
 	}
-	else
-	{
+	else {
 		// busy converting
 		return false;
 	}
@@ -389,18 +385,15 @@ float MAX30105::readTemperature(bool isAsync) {
 	
   //DIE_TEMP_RDY interrupt must be enabled
   //See issue 19: https://github.com/sparkfun/SparkFun_MAX3010x_Sensor_Library/issues/19
-	if (!isAsync)
-	{
+	if (!isAsync) {
 		// Step 1: Config die temperature register to take 1 temperature sample
 		writeRegister8(_i2caddr, MAX30105_DIETEMPCONFIG, 0x01);
 	}
-	if (!isAsync)
-	{
+	if (!isAsync) {
 		// Poll for bit to clear, reading is then complete
 		// Timeout after 100ms
 		unsigned long startTime = millis();
-		while (millis() - startTime < 100)
-		{
+		while (millis() - startTime < 100) {
 			//uint8_t response = readRegister8(_i2caddr, MAX30105_DIETEMPCONFIG); //Original way
 			//if ((response & 0x01) == 0) break; //We're done!
 
@@ -422,11 +415,9 @@ float MAX30105::readTemperature(bool isAsync) {
 }
 
 // Returns die temp in F Asynchronously
-bool MAX30105::getTemperatureF(float& temperature)
-{
+bool MAX30105::getTemperatureF(float& temperature) {
 	float temp;
-	if (!getTemperature(temp))
-	{
+	if (!getTemperature(temp)) {
 		return false;
 	}
 	

--- a/src/MAX30105.h
+++ b/src/MAX30105.h
@@ -114,7 +114,15 @@ class MAX30105 {
   void setPROXINTTHRESH(uint8_t val);
 
   // Die Temperature
-  float readTemperature();
+
+  /*!
+		@brief returns PPG die temerature if conversion is conplete
+				Note: it is necessary to call ienableDIETEMPRDY() to enable temp measurements
+		@param temperature die temperature
+		@return true is temperature succesfully read, else false
+  */
+  bool readTemperature(float& temperature);
+  float readTemperature(bool isAsync = false);
   float readTemperatureF();
 
   // Detecting ID/Revision

--- a/src/MAX30105.h
+++ b/src/MAX30105.h
@@ -121,8 +121,9 @@ class MAX30105 {
 		@param temperature die temperature
 		@return true is temperature succesfully read, else false
   */
-  bool readTemperature(float& temperature);
+  bool readTemperatureAsync(float& temperature);
   float readTemperature(bool isAsync = false);
+  bool readTemperatureFAsync(float& temperature);
   float readTemperatureF();
 
   // Detecting ID/Revision

--- a/src/MAX30105.h
+++ b/src/MAX30105.h
@@ -114,16 +114,21 @@ class MAX30105 {
   void setPROXINTTHRESH(uint8_t val);
 
   // Die Temperature
-
+  /*!
+		@brief sets the register to start a temperature measurement
+			Important to call this function before getTemperature is called
+  */
+  void startTempMeasurement();
+  
   /*!
 		@brief returns PPG die temerature if conversion is conplete
 				Note: it is necessary to call ienableDIETEMPRDY() to enable temp measurements
-		@param temperature die temperature
-		@return true is temperature succesfully read, else false
+		@param temperature measured die temperature
+		@return true if temperature measurement ready, else false
   */
-  bool readTemperatureAsync(float& temperature);
+  bool getTemperature(float& temperature);
   float readTemperature(bool isAsync = false);
-  bool readTemperatureFAsync(float& temperature);
+  bool getTemperatureF(float& temperature);
   float readTemperatureF();
 
   // Detecting ID/Revision


### PR DESCRIPTION
# Description 
- adds functionality to read temperature from PPG sensor asynchronously.

# Tests
## Asyncronous measurement
![image](https://user-images.githubusercontent.com/31810812/149404161-844c8985-0c9b-403b-ba45-c3ed38a212e6.png)
Pinging the sensor with a 10ms delay, the temperature is available only after ~30ms because the conversion time according to the data sheet is 29mS

## Synchronous measurement
![image](https://user-images.githubusercontent.com/31810812/149404361-23ef21a1-bc89-4a9b-82b5-9e07a69af173.png)
The synchronous access without any delay takes ~29ms, as described in the data sheet
