### PR TITLE
Feat 100 hz ppg

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MAX30101
-version=1.1.4
+version=2.0.0
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs<nitin@connectedfuturelabs.com>
 sentence=Library for the MAX30101 Pulse sensor on board the EmotiBit-Beta boards

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -57,6 +57,23 @@
 
 #include "heartRate.h"
 
+#include <Filters.h>
+#include <Filters/Butterworth.hpp>
+
+#ifdef EMOTIBIT_PPG_100HZ
+// Sampling frequency
+const double f_s = 100; // Hz
+#else
+// Sampling frequency
+const double f_s = 25; // Hz
+#endif
+// Cut-off frequency (-3 dB)
+const double f_c = 3; // Hz
+// Normalized cut-off frequency
+const double f_n = 2 * f_c / f_s;
+
+auto filter = butter<2>(f_n);  // choosing a second order butterworth filter
+
 int16_t IR_AC_Max = 20;
 int16_t IR_AC_Min = -20;
 
@@ -78,20 +95,16 @@ static const uint16_t FIRCoeffs[12] = {172, 321, 579, 927, 1360, 1858, 2390, 291
 //  Heart Rate Monitor functions takes a sample value and the sample number
 //  Returns true if a beat is detected
 //  A running average of four samples is recommended for display on the screen.
-bool checkForBeat(int32_t sample)
+bool checkForBeat(int32_t sample, int16_t &iirFiltData)
 {
   bool beatDetected = false;
 
   //  Save current state
   IR_AC_Signal_Previous = IR_AC_Signal_Current;
   
-  //This is good to view for debugging
-  //Serial.print("Signal_Current: ");
-  //Serial.println(IR_AC_Signal_Current);
-
   //  Process next data sample
-  IR_Average_Estimated = averageDCEstimator(&ir_avg_reg, sample);
-  IR_AC_Signal_Current = lowPassFIRFilter(sample - IR_Average_Estimated);
+  IR_AC_Signal_Current = lowPassIIRFitler(sample);  // sample is already IIR high pass filtered in EmotiBit cpp
+  iirFiltData = IR_AC_Signal_Current;
 
   //  Detect positive zero crossing (rising edge)
   if ((IR_AC_Signal_Previous < 0) & (IR_AC_Signal_Current >= 0))
@@ -104,7 +117,6 @@ bool checkForBeat(int32_t sample)
     negativeEdge = 0;
     IR_AC_Signal_max = 0;
 
-    //if ((IR_AC_Max - IR_AC_Min) > 100 & (IR_AC_Max - IR_AC_Min) < 1000)
     if ((IR_AC_Max - IR_AC_Min) > 20 & (IR_AC_Max - IR_AC_Min) < 1000)
     {
       //Heart beat!!!
@@ -158,6 +170,11 @@ int16_t lowPassFIRFilter(int16_t din)
   offset %= 32; //Wrap condition
 
   return(z >> 15);
+}
+
+int16_t lowPassIIRFitler(int16_t sample)
+{
+  return filter(sample);
 }
 
 //  Integer multiplier

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -117,7 +117,7 @@ bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved)
     negativeEdge = 0;
     IR_AC_Signal_max = 0;
 
-    if ((IR_AC_Max - IR_AC_Min) > 20 & (IR_AC_Max - IR_AC_Min) < 1000)
+    if ((IR_AC_Max - IR_AC_Min) > 20 & (IR_AC_Max - IR_AC_Min) < 2000)
     {
       //Heart beat!!!
       beatDetected = true;

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -87,11 +87,6 @@ int16_t positiveEdge = 0;
 int16_t negativeEdge = 0;
 int32_t ir_avg_reg = 0;
 
-int16_t cbuf[32];
-uint8_t offset = 0;
-
-static const uint16_t FIRCoeffs[12] = {172, 321, 579, 927, 1360, 1858, 2390, 2916, 3391, 3768, 4012, 4096};
-
 //  Heart Rate Monitor functions takes a sample value and the sample number
 //  Returns true if a beat is detected
 bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved)
@@ -159,23 +154,6 @@ int16_t averageDCEstimator(int32_t *p, uint16_t x)
   return (*p >> 15);
 }
 
-//  Low Pass FIR Filter
-int16_t lowPassFIRFilter(int16_t din)
-{  
-  cbuf[offset] = din;
-
-  int32_t z = mul16(FIRCoeffs[11], cbuf[(offset - 11) & 0x1F]);
-  
-  for (uint8_t i = 0 ; i < 11 ; i++)
-  {
-    z += mul16(FIRCoeffs[i], cbuf[(offset - i) & 0x1F] + cbuf[(offset - 22 + i) & 0x1F]);
-  }
-
-  offset++;
-  offset %= 32; //Wrap condition
-
-  return(z >> 15);
-}
 
 int16_t lowPassIIRFitler(float sample)
 {

--- a/src/heartRate.h
+++ b/src/heartRate.h
@@ -61,8 +61,8 @@
  #include "WProgram.h"
 #endif
 
-bool checkForBeat(int32_t sample, int16_t &iirFiltData);
+bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved = false);
 int16_t averageDCEstimator(int32_t *p, uint16_t x);
 int16_t lowPassFIRFilter(int16_t din);
-int16_t lowPassIIRFitler(int16_t sample);
+int16_t lowPassIIRFitler(float sample);
 int32_t mul16(int16_t x, int16_t y);

--- a/src/heartRate.h
+++ b/src/heartRate.h
@@ -61,7 +61,8 @@
  #include "WProgram.h"
 #endif
 
-bool checkForBeat(int32_t sample, int16_t &dcEst, int16_t &dcRemoved, int16_t &firFiltData);
+bool checkForBeat(int32_t sample, int16_t &iirFiltData);
 int16_t averageDCEstimator(int32_t *p, uint16_t x);
 int16_t lowPassFIRFilter(int16_t din);
+int16_t lowPassIIRFitler(int16_t sample);
 int32_t mul16(int16_t x, int16_t y);

--- a/src/heartRate.h
+++ b/src/heartRate.h
@@ -61,6 +61,13 @@
  #include "WProgram.h"
 #endif
 
+/*!
+ * @brief Function to detect heart beats from PPG signal
+ * @param sample Next input sample from the time series data
+ * @param iirFiltData The result of the filtered data. Use this variable to pass filtered result to the calling function
+ * @param dcRemoved Set to true if input has been low pass filtered before checking for a beat
+ * @return True if beat is detected, else False
+ */
 bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved = false);
 int16_t averageDCEstimator(int32_t *p, uint16_t x);
 int16_t lowPassIIRFitler(float sample);

--- a/src/heartRate.h
+++ b/src/heartRate.h
@@ -63,6 +63,5 @@
 
 bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved = false);
 int16_t averageDCEstimator(int32_t *p, uint16_t x);
-int16_t lowPassFIRFilter(int16_t din);
 int16_t lowPassIIRFitler(float sample);
 int32_t mul16(int16_t x, int16_t y);

--- a/src/heartRate.h
+++ b/src/heartRate.h
@@ -61,7 +61,7 @@
  #include "WProgram.h"
 #endif
 
-bool checkForBeat(int32_t sample);
+bool checkForBeat(int32_t sample, int16_t &dcEst, int16_t &dcRemoved, int16_t &firFiltData);
 int16_t averageDCEstimator(int32_t *p, uint16_t x);
 int16_t lowPassFIRFilter(int16_t din);
 int32_t mul16(int16_t x, int16_t y);


### PR DESCRIPTION
# Description
- `CheckForBeat()` function is modified 
  - Now, you can choose to skip the DC estimator inside the `checkForBeat` function and use a simple IIR HPF in the calling function. For us, it is `processHeartRate` in `EmotiBit.cpp`
  - The low pass filter, before peak detection,  has been changed to  `IIR filter`
- This change should support filtering for signals sampled at frequencies other than 25Hz.

# Breaking changes
- This PR modifies the `CheckForBeat()` function call.
  - It is compatible with the firmware changes made in this PR: https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/244 
- You will also need an additional library, linked in the requirements below


# Requirements
- https://github.com/EmotiBit/EmotiBit_ArduinoFilters

# Proposed future edits
- https://github.com/EmotiBit/EmotiBit_MAX30101/issues/9

# Issues Referenced
<!-- If Any -->
- Fixes # (issue)
