### PR TITLE
Improve HR detection based on dynamic bounds

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MAX30101
-version=2.0.2
+version=2.0.3
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs<nitin@connectedfuturelabs.com>
 sentence=Library for the MAX30101 Pulse sensor on board the EmotiBit-Beta boards

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MAX30101
-version=2.0.1
+version=2.0.2
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs<nitin@connectedfuturelabs.com>
 sentence=Library for the MAX30101 Pulse sensor on board the EmotiBit-Beta boards

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MAX30101
-version=2.0.0
+version=2.0.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs<nitin@connectedfuturelabs.com>
 sentence=Library for the MAX30101 Pulse sensor on board the EmotiBit-Beta boards

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -73,9 +73,10 @@ const double f_c = 3; // Hz
 const double f_n = 2 * f_c / f_s;
 
 auto filter = butter<2>(f_n);  // choosing a second order butterworth filter
+auto acSignalAmplitudeFilter = butter<1>(0.4);  // choosing a second order butterworth filter to smooth the acSignal 
+// following filters are added for testing. Will be removed from mainline code
 auto acSignalAmplitudeFilter_P1_FN_02 = butter<1>(0.2);  // choosing a second order butterworth filter to smooth the acSignal 
 auto acSignalAmplitudeFilter_P1_FN_03 = butter<1>(0.3);  // choosing a second order butterworth filter to smooth the acSignal 
-auto acSignalAmplitudeFilter = butter<1>(0.4);  // choosing a second order butterworth filter to smooth the acSignal 
 auto acSignalAmplitudeFilter_P1_FN_05 = butter<1>(0.5);  // choosing a second order butterworth filter to smooth the acSignal 
 auto acSignalAmplitudeFilter_P1_FN_06 = butter<1>(0.6);  // choosing a second order butterworth filter to smooth the acSignal 
 const int16_t IR_AC_MIN_AMP = 20;  // EmotiBit with no finger usually presents AC noise in the 0-10 range
@@ -153,6 +154,7 @@ bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved)
     {
       Serial.print("NOT DETECTED (NOISE),");
     }
+    // serial prints for testing/debugging
     Serial.print(IR_AC_amplitude); Serial.print(",");
     Serial.print(acAmpLowerBound); Serial.print(",");
     Serial.print(filteredAcAmp); Serial.print(",");

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -132,8 +132,8 @@ bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved)
     
     filteredAcAmp = acSignalAmplitudeFilter.filter(IR_AC_amplitude);
     acRange = acRangeFitler.filter(filteredAcAmp);
-    acAmpUpperBound = filteredAcAmp + (acRange * AC_RANGE_MULTIPLIER);  // Upper bound is half channel width above AC Signal
-    acAmpLowerBound = filteredAcAmp - (acRange * AC_RANGE_MULTIPLIER);  // Lower bound is half channel width below AC Signal
+    acAmpUpperBound = filteredAcAmp + (acRange * AC_RANGE_MULTIPLIER);  // Upper bound is adjusted based on acRange and range multiplier
+    acAmpLowerBound = filteredAcAmp - (acRange * AC_RANGE_MULTIPLIER);  // Lower bound is adjusted based on acRange and range multiplier
  
     Serial.print(millis()); Serial.print(",");
     if (IR_AC_amplitude > IR_AC_MIN_AMP & IR_AC_amplitude < IR_AC_MAX_AMP)

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -79,8 +79,8 @@ auto acSignalAmplitudeFilter_P1_FN_02 = butter<1>(0.2);  // choosing a second or
 auto acSignalAmplitudeFilter_P1_FN_03 = butter<1>(0.3);  // choosing a second order butterworth filter to smooth the acSignal 
 auto acSignalAmplitudeFilter_P1_FN_05 = butter<1>(0.5);  // choosing a second order butterworth filter to smooth the acSignal 
 auto acSignalAmplitudeFilter_P1_FN_06 = butter<1>(0.6);  // choosing a second order butterworth filter to smooth the acSignal 
-const int16_t IR_AC_MIN_AMP = 20;  // EmotiBit with no finger usually presents AC noise in the 0-10 range
-const int16_t IR_AC_MAX_AMP = 10000;  // A movement artifact usually registers on this high range. Normal IR range usually lieas  beloe 2000
+const int16_t IR_AC_MIN_AMP = 20;  // ABS MIN to consider it as a valid AC signal. EmotiBit with no finger usually presents AC noise in the 0-10 range
+const int16_t IR_AC_MAX_AMP = 10000;  // ABS MAX to consider it as a valid AC signal
 
 int16_t IR_AC_Max = 20;
 int16_t IR_AC_Min = -20;

--- a/src/heartRate.cpp
+++ b/src/heartRate.cpp
@@ -94,8 +94,8 @@ int32_t ir_avg_reg = 0;
 
 int16_t filteredAcAmp;
 int16_t acRange;
-int16_t acAmpUpperBound;  // This scaling factor is chosen as it works reasonably well with test conditions
-int16_t acAmpLowerBound;  // This scaling factor is chosen as it works reasonably well with test conditions
+int16_t acAmpUpperBound;
+int16_t acAmpLowerBound;
 
 //  Heart Rate Monitor functions takes a sample value and the sample number
 //  Returns true if a beat is detected
@@ -130,31 +130,24 @@ bool checkForBeat(int32_t sample, int16_t &iirFiltData, bool dcRemoved)
     acAmpUpperBound = filteredAcAmp + (acRange * AC_RANGE_MULTIPLIER);  // Upper bound is adjusted based on acRange and range multiplier
     acAmpLowerBound = filteredAcAmp - (acRange * AC_RANGE_MULTIPLIER);  // Lower bound is adjusted based on acRange and range multiplier
  
-    Serial.print(millis()); Serial.print(",");
     if ((IR_AC_amplitude > IR_AC_MIN_AMP) && (IR_AC_amplitude < IR_AC_MAX_AMP))
     {
       // signal is within ABS bounds
       if(IR_AC_amplitude > acAmpLowerBound && IR_AC_amplitude < acAmpUpperBound)
       {
         // signal is within the filtered signal bounds
-        Serial.print("BEAT DETECTED,");
         //Heart beat!!!
         beatDetected = true;
       }
       else
       {
-        Serial.print("NOT DETECTED (OOB),");
+        // Ac signal is out of permissible range. Do nothing.
       }
     }
     else
     {
-      Serial.print("NOT DETECTED (NOISE),");
+      // Ac signal is noise. Do nothing.
     }
-    // serial prints for testing/debugging
-    Serial.print(IR_AC_amplitude); Serial.print(",");
-    Serial.print(acAmpLowerBound); Serial.print(",");
-    Serial.print(filteredAcAmp); Serial.print(",");
-    Serial.println(acAmpUpperBound); 
   }
 
   //  Detect negative zero crossing (falling edge)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
Introduces dynamic bounds check for AC component of filtered PPG:IR channel. This patch improves the overall beat detection.


# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
- None

# Algorithm explanation
- Heart beats are detected by
  - HP filtering the PPG:IR channel to remove respiration.
  - The resulting wave is smoothed out to create a smooth sinusoid, that represents the change in the signal due to the heart beats.
  - The magnitude of this sinusoid represents the AC content in the original PPG:IR signal.
  - Originally, the magnitude was compared to a hard coded threshold, that created a lot of false positives and false negatives.
  - This PR introduces a dynamic thresholding, where an "acceptable channel (range)" of specified width is created, which improves beat classification.
- The dynamic channel is governed by 2 variables
  - the pass-band frequency of the underlying AC_signal content
  - the channel width.
- The pass-band frequency is of greater importance as it determines the channel shape and transient characteristics and hence, it has been discussed further below.

# Testing
## Steps for testing
- Flash the Fw linked below in the [shared files](#shared-files) section.
- Run the FW and collect data as shown in the comments below (using the serial monitor)
- Ground truth label the data
- Assess the algorithm performance
- Tweak the algorithm parameters (filter frequencies and range multiplier) if needed.
- Assess performance again.
- Check out the `Heartbeat Det AC Filter Calculator` sheet for testing results + design and analysis of algorithm.

## AC content filtering
### AC content expailned
- As seen in the image below, for a given PPG signal, there is a `AC content` in the signal which is determined by heart beats, as well as other physiological and non-physiological factors.
  - Physiological factors
    - Changes due to breathing
    - Changes due to physiological responses, ex: sitting -> standing movement
  - Non-Physiological factors
    - Motion artifacts
    - sensor pressure changes (someone unintentionally presses the sensor harder against the skin)

| AC signal content in a stable environment | AC signal content in motion|
| ----------------------------------------------| -------------------------------|
|![AC_signal_content](https://user-images.githubusercontent.com/31810812/230502665-f0bbc155-336c-4cfb-8485-8517a4427268.png) | ![image](https://user-images.githubusercontent.com/31810812/230503514-757ac772-b302-48ec-842e-c32f0f208cec.png)|

### Effect of filter cutoff frequency
- Choosing the cutoff frequency is about creating a balance between accepting/rejecting AC signal variation caused by physiological and non-physiological changes.
  - We want to keep physiological changes
  - We want to discard the non-physiological events
  - Lowering the cutoff frequency makes the "acceptable dynamic region" more constant and less inertial. We therefore risk losing physiological changes if the cutoff is too low.
  - raising the cutoff frequency makes the "acceptable dynamic region" more fluid and responsive. We therefore, risk accepting non-physiological changes as valid physiological events.
- Below is a list of snippets comparing the filter responses from filters designed using normalized cutoff frequency as
  - `fn`  = `0.2`, `0.3`, `0.4`, `0.5`, `0.6`

|Scenario | filter responses|
|----------|----------|
| **Deep breathing** <br> As seen, more "strict" filters (0.2 and 0.3) fail to adjust fast enough, causing some of the valid AC signal changes to be flagged as "not a beat"| ![image](https://user-images.githubusercontent.com/31810812/230505005-c58101e2-dc13-49d2-bb34-e89fa2bfc9d4.png)|
|**Sharp presses on Emotibit** <br> As seen, the sharp presses cause the AC signal content to spike (as evident in the original IR data). Here low pass filters with cutoff of 0.2/0.3/0.4 perform better than 0.6 (which is not strict enough) and allows the AC signal spikes to be counted as valid "beats | ![image](https://user-images.githubusercontent.com/31810812/230505644-3fa4f5e6-f256-4bef-b4b0-bb53cf4be833.png) |
| **Motion artifacts** <br> As seen, motion artifacts create a spike in AC content, which are dealt with by the filters pretty efficiently | ![image](https://user-images.githubusercontent.com/31810812/230505876-6682a307-380c-4f12-a700-f906883560b3.png)|
|**sit <> stand responses** <br> All filters deal with changes introduced by sit<>stand pretty effectively. Although, the AC changes here are not large and maybe that contributes to the good response of the filters, it may vary for different people, if a bigger physiological response is created when they sit<>stand. | ![image](https://user-images.githubusercontent.com/31810812/230655345-8d7636bd-06fe-4dcd-b14d-b0ad23f5bfbe.png)|


### Conclusion
- We decided to go with simple 1-pole filters to process the IR signal and create the dynamic range to acceptable AC values
- The chosen values that worked the best on the limited dataset/testing is pasted below
```
DigitalFilter acSignalAmplitudeFilter(DigitalFilter::FilterType::IIR_LOWPASS, 10, 1); //< create normalized cutoff of 0.1. Chosen based on testing and analysis in "Heartbeat Det AC Filter Calculator" testing sheet
DigitalFilter acRangeFitler(DigitalFilter::FilterType::IIR_LOWPASS, 10, 5); //< create normalized cutoff of 0.1. Chosen based on testing and analysis in "Heartbeat Det AC Filter Calculator" testing sheet
const float AC_RANGE_MULTIPLIER = 1.f/1.5;  // Chosen based on testing and analysis in "Heartbeat Det AC Filter Calculator" testing sheet
```

# Shared files
- flash the Emotibit with the following binaries: 
  - [~1.8.0.fix-improveHr.1.zip~](https://github.com/EmotiBit/EmotiBit_MAX30101/files/11174886/1.8.0.fix-improveHr.1.zip)  
  - [~1.8.0.fix-improveHr.2.zip~](https://github.com/EmotiBit/EmotiBit_MAX30101/files/11184654/1.8.0.fix-improveHr.2.zip) 
  - [~1.8.0.fix-improveHr.3.zip~](https://github.com/EmotiBit/EmotiBit_MAX30101/files/11213261/1.8.0.fix-improveHr.3.zip)
  - [1.8.0.fix-improveHr.4.zip](https://github.com/EmotiBit/EmotiBit_MAX30101/files/11225015/1.8.0.fix-improveHr.4.zip) (After addressing review 01 comments. contains 100Hz PPG binaries)


- The code, data and PDFs of the graphs are linked here: [improve_hr.zip](https://github.com/EmotiBit/EmotiBit_MAX30101/files/11179640/improve_hr.zip)
- For the python script to work "as is", the directory structure for the files should be
```
dir
|- hearRate-dynamicBoundsAnalysis.py
|- data
    |-- <basename>_serial_output.csv
    |-- emotibit_data
         |-- basename
              |-- parsed files
```
- You can always change the script to modify the file locations.


# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Firmware
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated

## Screenshots:
